### PR TITLE
Only overwrite stored details in database if new info

### DIFF
--- a/evewspace/Map/views.py
+++ b/evewspace/Map/views.py
@@ -498,9 +498,11 @@ def _update_sig_from_tsv(signature, row):
     if info and sig_type:
         updated = True
 
-    signature.sigtype = sig_type
-    signature.updated = updated
-    signature.info = info
+    if sig_type:
+        signature.sigtype = sig_type
+    signature.updated = updated or signature.updated
+    if info:
+        signature.info = info
 
     return signature
 


### PR DESCRIPTION
Bulk import always assumed information given was the most current. This meant reimporting an old sig would delete everything.
