### PR TITLE
Add an updated signature signal

### DIFF
--- a/evewspace/Map/signals.py
+++ b/evewspace/Map/signals.py
@@ -1,0 +1,19 @@
+#    Eve W-Space
+#    Copyright (C) 2013  Andrew Austin and other contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version. An additional term under section
+#    7 of the GPL is included in the LICENSE file.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from django.dispatch import Signal
+
+signature_update = Signal(providing_args=['user', 'signal_strength'])


### PR DESCRIPTION
Allows corp-specific apps to hook into scanners for payment or other logging.
