### PR TITLE
Stop long sig names forcing a second line.

### DIFF
--- a/evewspace/Map/static/css/map.css
+++ b/evewspace/Map/static/css/map.css
@@ -100,6 +100,7 @@
 .signatureListDiv
 {
     text-align: left;
+    white-space: nowrap;
 }
 .sysSigsList
 {


### PR DESCRIPTION
When long names were entered into the "Info" field previously it would break the table format like this: 
![image](https://f.cloud.github.com/assets/686559/1027863/c07af0f8-0e79-11e3-93a1-160355285d6a.png)

With this patch it is a single line ie this:

![image](https://f.cloud.github.com/assets/686559/1027866/cc29b4ca-0e79-11e3-88cc-0f2f58066a89.png)
