### PR TITLE
Add modify age and editor to signatures

### DIFF
--- a/evewspace/Map/models.py
+++ b/evewspace/Map/models.py
@@ -359,6 +359,7 @@ class SignatureType(models.Model):
 class Signature(models.Model):
     """Stores the signatures active in all systems. Relates to System model."""
     system = models.ForeignKey(System, related_name="signatures")
+    user = models.ForeignKey(User, related_name="signatures")
     sigtype = models.ForeignKey(SignatureType, related_name="sigs", null=True, blank=True)
     sigid = models.CharField(max_length = 10)
     updated = models.BooleanField()
@@ -372,6 +373,7 @@ class Signature(models.Model):
     downtimes = models.IntegerField(null=True, blank=True)
     ratscleared = models.DateTimeField(null=True, blank=True)
     lastescalated = models.DateTimeField(null=True, blank=True)
+    lastmodification = models.DateTimeField(auto_now=True,null=True,blank=True)
 
     class Meta:
         ordering = ['sigid']
@@ -426,6 +428,24 @@ class Signature(models.Model):
         """Mark the signature as having been updated since DT."""
         self.updated = True
         self.save()
+
+    def time_since_modification(self):
+        """How much time since it was modified"""
+        str=""
+        seconds = (datetime.now(pytz.utc) - self.lastmodification).seconds
+        
+        if seconds/60/60 > 0:
+            str += "%dh" % (seconds/60/60)
+            seconds -= (seconds/60/60) * (60*60)
+
+        if seconds/60 > 0:
+            str += " %dm" % (seconds/60)
+            seconds -= (seconds/60) * 60
+            
+        if seconds > 0:
+            str += " %ds" % (seconds)
+
+        return str;
 
     def save(self, *args, **kwargs):
         """

--- a/evewspace/Map/templates/system_signatures.html
+++ b/evewspace/Map/templates/system_signatures.html
@@ -7,6 +7,8 @@
     <th>Info</th>
     <th>Act. / Rats</th>
     <th>Escl.</th>
+    <th>ModAge</th>
+    <th>Who</th>
     </tr>
     {% for sig in system.system.signatures.all %}
     <tr>
@@ -58,6 +60,9 @@
                 {% endif %}    
                 {% endif %}
             </td>
+            <td><span class="editTime">{{sig.time_since_modification}}</span> </td>
+            <td><span class="editName">{{sig.user.username}}</span> </td>
+
         {% empty %}
         <tr><td>No Signatures!</td></tr>
     </tr>

--- a/evewspace/Map/views.py
+++ b/evewspace/Map/views.py
@@ -481,7 +481,7 @@ def bulk_sig_import(request, map_id, ms_id):
                         status=400)
             if k < 75:
                 sig_id = utils.convert_signature_id(row[COL_SIG])
-                sig = Signature.objects.get_or_create(sigid=sig_id,
+                sig = Signature.objects.get_or_create(sigid=sig_id, user=request.user,
                         system=map_system.system)[0]
                 sig = _update_sig_from_tsv(sig, row)
                 sig.save()
@@ -535,6 +535,7 @@ def edit_signature(request, map_id, ms_id, sig_id=None):
             else:
                 sigtype = None
             signature.sigtype = sigtype
+            signature.user = request.user
             signature.save()
             map_system.system.lastscanned = datetime.now(pytz.utc)
             map_system.system.save()


### PR DESCRIPTION
When there are multiple pilots scouting a single
system in parallel, it helps to see who modified
a signature and when. Editing a signature can be
thought of as claiming for ownership so that
collisions in scouting work are minimized.

Signed-off-by: Mika Kuoppala miku@iki.fi
