### PR TITLE
Fetch sigs even if different users. Fixes #EW-85

### DIFF
--- a/evewspace/Map/views.py
+++ b/evewspace/Map/views.py
@@ -482,7 +482,6 @@ def bulk_sig_import(request, map_id, ms_id):
             if k < 75:
                 sig_id = utils.convert_signature_id(row[COL_SIG])
                 sig = Signature.objects.get_or_create(sigid=sig_id,
-                        modified_by=request.user,
                         system=map_system.system)[0]
                 sig = _update_sig_from_tsv(sig, row)
                 sig.modified_by = request.user


### PR DESCRIPTION
Previously, when doing bulk imports, old sigs were only being found if last edited by the current user. This pull request fetches this.

WARNING: Due to the bug this is fixing, it is possible that the database contains multiple entries for sig_id, system combinations. These will cause an error to be thrown if bulk_import is run on that system. 
