### PR TITLE
Fix error on trying to create a 'next' button for the last page of the u...

### DIFF
--- a/evewspace/account/templates/user_list.html
+++ b/evewspace/account/templates/user_list.html
@@ -43,6 +43,7 @@
                     });
                 });
         {% endif %}
+    {% if member_list.number < member_list.paginator.num_pages %}
         $('#userNextLink').click(function(){
                 $.ajax({
                     url: "/account/admin/user/list/{{member_list.next_page_number}}/",
@@ -57,6 +58,7 @@
                     }
                     });
                 });
+        {% endif %}
     </script>
 
 </div>


### PR DESCRIPTION
Currently it isn't possible to get to the last page of user listings in the 'Settings'->'Users' section. A bit of digging revealed this was because member_list.next_page_number was throwing an error for "EmptyPage: That page contains no results". This change means we avoid that call if we are building the last page.
