### PR TITLE
Changed wormhol.es link to wh.pasta.gg

### DIFF
--- a/evewspace/Map/templates/system_menu.html
+++ b/evewspace/Map/templates/system_menu.html
@@ -43,7 +43,7 @@
         {% endif %}
         <li><a href="http://zkillboard.com/system/{{system.pk}}" target="_blank">zKillboard</a></li>
         {% if system.sysclass < 7 %}
-        <li><a href="http://www.wormhol.es/{{system.name}}" target="_blank">Wormhol.es</a></li>
+        <li><a href="http://wh.pasta.gg/{{system.name}}" target="_blank">Wormhol.es</a></li>
         {% endif %}
 
     </ul>


### PR DESCRIPTION
Considering wormhol.es has been down for a while now and the new link (wh.pasta.gg) hadn't been put in yet, I figured I'd give a go at it myself :P
