### PR TITLE
Vagrant up fails: missing dependency

### DIFF
--- a/puppet/manifests/development.pp
+++ b/puppet/manifests/development.pp
@@ -57,6 +57,11 @@ package {'rabbitmq-server':
 	require => Exec['apt-get update']
     }
 
+package {'python-mysqldb':
+	ensure => present,
+	require => Exec['apt-get update']
+	}
+
 service {'rabbitmq-server':
     ensure => 'running',
     hasrestart => 'true',


### PR DESCRIPTION
Vagrant provisioning failed in a couple places. Full log is [here](http://pastebin.com/CyZNAMeN)

```
==> default: err: /Stage[main]//Exec[create-db]/returns: change from notrun to 0 failed: /usr/bin/mysql -e "create database djangotest character set utf8;" && /vagrant/puppet/scripts/django_load_db.sh returned 1 instead of one of [0] at /tmp/vagrant-puppet-4/manifests/development.pp:90
==> default: notice: Finished catalog run in 508.23 seconds
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

puppet apply --modulepath '/tmp/vagrant-puppet-4/modules-0:/etc/puppet/modules' --manifestdir /tmp/vagrant-puppet-4/manifests --detailed-exitcodes /tmp/vagrant-puppet-4/manifests/development.pp

```
