### PR TITLE
Added documentation for SMTP settings, fixed misnamed settings.

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -92,3 +92,30 @@ From the UI:::
 
 You can give this group basic map permissions from the Map Admin panel under
 the "Global Permissions" section.
+
+Configure an E-Mail Server
+--------------------------
+
+If you want to send users password recovery e-mails or send admins error logs
+when they happen, you'll need to configure an SMTP server to use. In this
+example we'll be using Gmail. You can try and set up your own server but
+you should know what you're doing at that point, so this guide doesn't cover it.
+
+First create a Gmail account with your preferred credentials. We're using
+*bob@evewspace.com* as an example. Open up your local_settings.py file.
+Uncomment and configure the e-mail related settings as follows.
+
+    SERVER_EMAIL='*<administrator e-mail here>*'
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    EMAIL_HOST = 'smtp.gmail.com'
+    EMAIL_PORT = 587
+    EMAIL_HOST_USER = 'bob@evewspace.com'
+    EMAIL_HOST_PASSWORD = '*<your gmail password here>*'
+    EMAIL_USE_TLS = True
+
+Reset your services with the following command;
+
+    $ sudo supervisorctl restart all
+
+Try and reset your password from the admin interface to see if it's working.
+If there's a problem many providers will return meaningful error messages.

--- a/evewspace/evewspace/local_settings.py.example
+++ b/evewspace/evewspace/local_settings.py.example
@@ -34,10 +34,10 @@ DATABASES = {
 # Set your E-mail options below if you need to override the defaults
 #SERVER_EMAIL='bob@J100820.wh'
 #EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-#EMAIL_HOST = 'localhost'
+#EMAIL_HOST = ''
 #EMAIL_PORT = 25
-#EMAIL_USER = ''
-#EMAIL_PASSWORD = ''
+#EMAIL_HOST_USER = ''
+#EMAIL_HOST_PASSWORD = ''
 #EMAIL_USE_TLS = False
 #
 #If you use the file e-mail backend, set this:


### PR DESCRIPTION
According to [Django Documentation](https://docs.djangoproject.com/en/1.7/topics/email/#smtp-backend) the settings file should set; `EMAIL_HOST_USER, EMAIL_HOST_PASSWORD` instead of `EMAIL_USER, EMAIL_PASSWORD`.

I've also added a basic tutorial about setting an SMTP configuration up.
