### PR TITLE
Drifter systems are shattered.

### DIFF
--- a/evewspace/Map/fixtures/wormholestatics.json
+++ b/evewspace/Map/fixtures/wormholestatics.json
@@ -4,7 +4,7 @@
     "model": "Map.wsystem", 
     "fields": {
         "static1": null, 
-        "is_shattered": false, 
+        "is_shattered": true, 
         "static2": null, 
         "effect": "Red Giant"
     }
@@ -14,7 +14,7 @@
     "model": "Map.wsystem", 
     "fields": {
         "static1": null, 
-        "is_shattered": false, 
+        "is_shattered": true, 
         "static2": null, 
         "effect": "Cataclysmic Variable"
     }
@@ -24,7 +24,7 @@
     "model": "Map.wsystem", 
     "fields": {
         "static1": null, 
-        "is_shattered": false, 
+        "is_shattered": true, 
         "static2": null, 
         "effect": "Magnetar"
     }
@@ -34,7 +34,7 @@
     "model": "Map.wsystem", 
     "fields": {
         "static1": null, 
-        "is_shattered": false, 
+        "is_shattered": true, 
         "static2": null, 
         "effect": "Pulsar"
     }
@@ -54,7 +54,7 @@
     "model": "Map.wsystem", 
     "fields": {
         "static1": null, 
-        "is_shattered": false, 
+        "is_shattered": true, 
         "static2": null, 
         "effect": "Wolf-Rayet Star"
     }


### PR DESCRIPTION
All the planets in those systems are shattered, and they also have no moons. A mysql query for reference:
 ```sql
SELECT w.solarSystemID, w.solarSystemName, m.itemName, i.typeName FROM mapSolarSystems AS w LEFT JOIN mapDenormalize AS m ON w.solarSystemID = m.solarSystemID LEFT JOIN invTypes AS i ON m.typeID = i.typeID WHERE m.groupID = 7 AND (w.solarSystemID = 31000001 OR m.solarSystemID = 31000002 OR m.solarSystemID = 31000003 OR m.solarSystemID = 31000004 OR m.solarSystemID = 31000006);
 ```