### PR TITLE
Prevent unnecessary sitetracker requests

### DIFF
--- a/evewspace/SiteTracker/static/js/sitetracker_functions.js
+++ b/evewspace/SiteTracker/static/js/sitetracker_functions.js
@@ -1,7 +1,5 @@
 var stRefreshTimerID = null;
-$(document).ready(function(){
-    ReloadSTBar();
-});
+
 function STCreateFleet(sysID){
     $.ajax({
         type: "POST",

--- a/evewspace/SiteTracker/static/js/sitetracker_functions.js
+++ b/evewspace/SiteTracker/static/js/sitetracker_functions.js
@@ -4,10 +4,7 @@ function STCreateFleet(sysID){
     $.ajax({
         type: "POST",
         data: 'sysID=' + sysID,
-        url: "/sitetracker/fleet/new/",
-        success: function(){
-            ReloadSTBar();
-        }
+        url: "/sitetracker/fleet/new/"
     });
 }
 

--- a/evewspace/SiteTracker/templates/st_status_bar.html
+++ b/evewspace/SiteTracker/templates/st_status_bar.html
@@ -1,5 +1,10 @@
 {% load static %}
 <script src="{% get_static_prefix %}js/sitetracker_functions.js" type="text/javascript"></script>
+<script>
+$(document).ready(function(){
+    ReloadSTBar();
+});
+</script>
 <link rel="stylesheet" type="text/css" href="{% get_static_prefix %}css/sitetracker.css" />
 {% load sitetracker %}
 <div id="stStatusHeader" class="stStatusHeader text-left" data-toggle="collapse" data-target="#stFleetListing">


### PR DESCRIPTION
SiteTracker was still doing regular requests to reload sitetracker data in map view but this is no longer necessary since it was moved to a separate page.