### PR TITLE
Added hints on wormhole effects because my memory sucks & a simple signature sequence counter

### DIFF
--- a/evewspace/Map/static/js/map_functions.js
+++ b/evewspace/Map/static/js/map_functions.js
@@ -304,7 +304,7 @@ function setEffectTip() {
         } else if (effect == "Pulsar") {
             tip = "Boosts Shield HP, NOS/neut drain amount; penalizes armor resists, capacitor recharge, signature radius";
             effectcolor = effectColorPulsar; 
-        } else if (effect == "Wolf Rayet") {
+        } else if (effect == "Wolf-Rayet Star") {
             tip = "Boosts Armor HP, small weapon damage, signature radius; penalizes shield resists";
             effectcolor = effectColorWolfRayet; 
         } else if (effect == "Black Hole") {

--- a/evewspace/Map/static/js/map_functions.js
+++ b/evewspace/Map/static/js/map_functions.js
@@ -279,10 +279,43 @@ function DisplaySystemDetails(msID, sysID) {
                 BulkImport(msID);
                 e.preventDefault();
             });
+            setEffectTip();
             focusMS = msID;
             StartDrawing();
         }
     });
+}
+
+function setEffectTip() {
+    var effect = $('#sysEffect').text();
+    if  (effect) {
+        //var cls = $('#sysClass').text();
+        var tip = "";
+        var effectcolor = "#aaaaaa"; 
+        if (effect == "Cataclysmic Variable") {
+            tip = "Boosts remote repair, shield transfer, capacitor capacity/recharge; penalizes local armor repair, shield boost, and remote capacitor";
+            effectcolor = effectColorCataclysmic; 
+        } else if (effect == "Magnetar") {
+            tip = "Boosts damage, missile radius; penalizes drone tracking, targeting range, tracking speed, target painter";
+            effectcolor = effectColorMagnetar; 
+        } else if (effect == "Red Giant") {
+            tip = "Boosts overload bonus, smart bomb range/damage, bomb damage; penalizes overload heat damage";
+            effectcolor = effectColorRedGiant; 
+        } else if (effect == "Pulsar") {
+            tip = "Boosts Shield HP, NOS/neut drain amount; penalizes armor resists, capacitor recharge, signature radius";
+            effectcolor = effectColorPulsar; 
+        } else if (effect == "Wolf Rayet") {
+            tip = "Boosts Armor HP, small weapon damage, signature radius; penalizes shield resists";
+            effectcolor = effectColorWolfRayet; 
+        } else if (effect == "Black Hole") {
+            tip = "Boosts missile (explosion) velocity, ship velocity, targeting range; penalizes statis webifier, inertia";
+            effectcolor = effectColorBlackHole; 
+        } else {
+            tip = "No special effect";
+        }
+        $('#sysEffect').attr('title',tip);
+        $('#sysEffect').css('color',effectcolor);
+    }
 }
 
 function GetPOSList(msID) {

--- a/evewspace/Map/templates/system_details.html
+++ b/evewspace/Map/templates/system_details.html
@@ -19,10 +19,10 @@
     <div class="sysClassSpan">
         {% if system.is_wspace %}
         <div class="span2">
-            <strong>Class: {{system.sysclass}}</strong>
+            <strong>Class: <span id="sysClass">{{system.sysclass}}</span></strong>
         </div>
         <div class="span2">
-            <strong>Effect: {{system.effect}}</strong>
+            <strong>Effect: <span id="sysEffect">{{system.effect}}</span></strong>
         </div>
         <div class="span2">
             <strong>Probable Statics:

--- a/evewspace/Map/templates/system_details_combined.html
+++ b/evewspace/Map/templates/system_details_combined.html
@@ -19,11 +19,11 @@
     {% endif %}
     <div class="sysClassSpan">
         {% if system.is_wspace %}
-        <div class="span2"> 
-            <strong>Class: {{system.sysclass}}</strong>
+        <div class="span2">
+            <strong>Class: <span id="sysClass">{{system.sysclass}}</span></strong>
         </div>
         <div class="span2">
-            <strong>Effect: {{system.effect}}</strong>
+            <strong>Effect: <span id="sysEffect">{{system.effect}}</span></strong>
         </div>
         <div class="span2">
             <strong>Probable Statics:

--- a/evewspace/Map/templates/system_signatures.html
+++ b/evewspace/Map/templates/system_signatures.html
@@ -1,6 +1,7 @@
 {% load humanize %}
 <table class="table table-condensed sysSigsTable" cellspacing="0">
     <tr>
+    <th>#</th>
     <th>Actions</th>
     <th>Sig ID</th>
     <th>Type</th>
@@ -11,6 +12,7 @@
     {% for sig in system.system.signatures.all %}
     <tr {% if sig.owned_by %}class="success"{% elif not sig.updated %} class="sig-not-updated"{% endif %}
         title="{% if not sig.updated %}Not yet scanned!{% else %}Scanned {{sig.modified_time|naturaltime}} by {{sig.modified_by}}.{% endif %}">
+        <td>{{ forloop.counter }}</td>
         <td>
             <i class="icon-pencil" title="Edit" onclick="GetEditSignatureBox({{system.pk}}, {{sig.pk}}, {{system.pk}});"></i> &nbsp;
             <i class="icon-ban-circle" title="Delete" onclick="DeleteSignature({{sig.pk}}, {{system.pk}});"></i> &nbsp; 
@@ -37,7 +39,7 @@
                                 MarkCleared({{sig.pk}}, {{system.pk}});
                                 } 
                                 {% endif %}
-                        });
+                        })
             </script>
             {% elif sig.sigtype.sleeprsite %}
             <i class="icon-screenshot" onclick="MarkCleared({{sig.pk}}, {{system.pk}});" title="NPCs cleared at {{sig.ratscleared|date:'Y-m-d H:i'}}"></i> 

--- a/evewspace/Map/templates/system_signatures.html
+++ b/evewspace/Map/templates/system_signatures.html
@@ -39,7 +39,7 @@
                                 MarkCleared({{sig.pk}}, {{system.pk}});
                                 } 
                                 {% endif %}
-                        })
+                        });
             </script>
             {% elif sig.sigtype.sleeprsite %}
             <i class="icon-screenshot" onclick="MarkCleared({{sig.pk}}, {{system.pk}});" title="NPCs cleared at {{sig.ratscleared|date:'Y-m-d H:i'}}"></i> 


### PR DESCRIPTION
1) When hovering over the wormhole effect label in the system details, a hint appears telling what the effect does. 
2) The wormhole effect label is colored with the same colours as in the mapper, for easy visualization.
3) A sequence counter for signatures is added so you can easily see how many signatures there are.

1 & 2 are implemented client-side (since the colors are defined client-side too).