### PR TITLE
Slack message

### DIFF
--- a/evewspace/Alerts/tasks.py
+++ b/evewspace/Alerts/tasks.py
@@ -35,7 +35,8 @@ def send_alert(from_user, sub_group, message, subject):
         for user in User.objects.filter(is_active=True):
             if user.has_perm('Alerts.can_alert'):
                 to_list.append(user)
+        results = {}
         for method in method_registry.registry:
-            method_registry.registry[method]().send_alert(to_list, subject, message,
-                    from_user, sub_group)
-        return method_registry.registry
+            results[method] = method_registry.registry[method]().send_alert(
+                    to_list, subject, message, from_user, sub_group)
+        return results

--- a/evewspace/Slack/slack_method.py
+++ b/evewspace/Slack/slack_method.py
@@ -14,13 +14,19 @@ class SlackAlertMethod(AlertMethodBase):
         subdomain = get_config("SLACK_SUBDOMAIN", None).value
 
         if self.exists(sub_group):
-            header = '%s - %s' % (from_user.username, subject)
             channel = SlackChannel.objects.get(group=sub_group)
             destination = "https://%s.slack.com/services/hooks/incoming-webhook?token=%s" % (subdomain, channel.token)
             payload = {'payload':json.dumps({'channel': channel.channel,
-                'username': "PingBOT",
-                'attachments':[{'fallback': "New alert!",
-                    'fields':[{'title': header, 'value': message}]}]})}
+                'username': "EVE W-Space",
+                'attachments':[{
+                    'pretext': 'Notifying <!channel> for new ping from <@%s>' % (from_user.username,),
+                    'fallback': "EWS-PING: %s - %s" % (subject, message),
+                    'fields':[{
+                        'title': subject,
+                        'value': message
+                    }]
+                }]
+            })}
             r = requests.post(destination, data=payload)
             return {'status_code': r.status_code, 'text': r.text}
 

--- a/evewspace/Slack/slack_method.py
+++ b/evewspace/Slack/slack_method.py
@@ -21,7 +21,8 @@ class SlackAlertMethod(AlertMethodBase):
                 'username': "PingBOT",
                 'attachments':[{'fallback': "New alert!",
                     'fields':[{'title': header, 'value': message}]}]})}
-            requests.post(destination, data=payload)
+            r = requests.post(destination, data=payload)
+            return {'status_code': r.status_code, 'text': r.text}
 
     def exists(self, group):
         """


### PR DESCRIPTION
This PR mages 3 main fixes to Slack integration. Mainly the message format should be better now (we can argue about this), alert message is readable over IRC slack gateway and slack http response is logged to celery.

ps. jabber_method.py doesn't return anything else than None for celery. Someone who uses that interface, could fix that.