### PR TITLE
Change defaultsettings to keep existing settings

### DIFF
--- a/evewspace/API/default_settings.py
+++ b/evewspace/API/default_settings.py
@@ -12,15 +12,12 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from core.models import ConfigEntry
-#defaults = [("TEST_SETTING", "BOB")]
+from core.utils import load_defaults
+from functools import partial
+
 defaults = [
         ("API_ALLOW_CHARACTER_KEY", "0"),
         ("API_ALLOW_EXPIRING_KEY", "0"),
         ]
 
-def load_defaults():
-    for setting in defaults:
-        config = ConfigEntry.objects.get_or_create(name=setting[0], user=None)[0]
-        config.value = setting[1]
-        config.save()
+load_defaults = partial(load_defaults, defaults)

--- a/evewspace/Jabber/default_settings.py
+++ b/evewspace/Jabber/default_settings.py
@@ -12,10 +12,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from core.models import ConfigEntry
+from core.utils import load_defaults
+from functools import partial
 import random
 import string
-#defaults = [("TEST_SETTING", "BOB")]
+
 defaults = [
         ("JABBER_FROM_JID", "announce@localhost"),
         ("JABBER_FROM_PASSWORD", ''.join(random.choice(string.ascii_uppercase + string.digits) for x in range(15))),
@@ -24,8 +25,4 @@ defaults = [
         ("JABBER_LOCAL_ENABLED", "0"),
         ]
 
-def load_defaults():
-    for setting in defaults:
-        config = ConfigEntry.objects.get_or_create(name=setting[0], user=None)[0]
-        config.value = setting[1]
-        config.save()
+load_defaults = partial(load_defaults, defaults)

--- a/evewspace/Map/default_settings.py
+++ b/evewspace/Map/default_settings.py
@@ -12,8 +12,9 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from core.models import ConfigEntry
-#defaults = [("TEST_SETTING", "BOB")]
+from core.utils import load_defaults
+from functools import partial
+
 defaults = [
     ("MAP_PVP_THRESHOLD", "0"),
     ("MAP_NPC_THRESHOLD", "10"),
@@ -35,13 +36,4 @@ defaults = [
     ("MAP_AUTODELETE_DAYS", "14"),
 ]
 
-
-def load_defaults():
-    '''
-    Loads default configuration settings.
-    '''
-    for setting in defaults:
-        config = ConfigEntry.objects.get_or_create(name=setting[0],
-                                                   user=None)[0]
-        config.value = setting[1]
-        config.save()
+load_defaults = partial(load_defaults, defaults)

--- a/evewspace/SiteTracker/default_settings.py
+++ b/evewspace/SiteTracker/default_settings.py
@@ -12,14 +12,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from core.models import ConfigEntry
-#defaults = [("TEST_SETTING", "BOB")]
+from core.utils import load_defaults
+from functools import partial
+
 defaults = [
         ("ST_SIZE_WEIGHT", "5"),
         ]
 
-def load_defaults():
-    for setting in defaults:
-        config = ConfigEntry.objects.get_or_create(name=setting[0], user=None)[0]
-        config.value = setting[1]
-        config.save()
+load_defaults = partial(load_defaults, defaults)

--- a/evewspace/Slack/default_settings.py
+++ b/evewspace/Slack/default_settings.py
@@ -1,14 +1,23 @@
-from core.models import ConfigEntry
-import random
-import string
-#defaults = [("TEST_SETTING", "BOB")]
+#   Eve W-Space
+#   Copyright 2014 Andrew Austin and contributors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from core.utils import load_defaults
+from functools import partial
+
 defaults = [
         ("SLACK_ENABLED", False),
         ("SLACK_SUBDOMAIN", "SLACK"),
         ]
 
-def load_defaults():
-    for setting in defaults:
-        config = ConfigEntry.objects.get_or_create(name=setting[0], user=None)[0]
-        config.value = setting[1]
-        config.save()
+load_defaults = partial(load_defaults, defaults)

--- a/evewspace/core/default_settings.py
+++ b/evewspace/core/default_settings.py
@@ -12,14 +12,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from core.models import ConfigEntry
-#defaults = [("TEST_SETTING", "BOB")]
+from core.utils import load_defaults
+from functools import partial
+
 defaults = [
         ("CORE_FEEDBACK_ENABLED", "0"),
         ]
 
-def load_defaults():
-    for setting in defaults:
-        config = ConfigEntry.objects.get_or_create(name=setting[0], user=None)[0]
-        config.value = setting[1]
-        config.save()
+load_defaults = partial(load_defaults, defaults)

--- a/evewspace/core/management/commands/defaultsettings.py
+++ b/evewspace/core/management/commands/defaultsettings.py
@@ -22,14 +22,23 @@ class Command(BaseCommand):
     """
     Load default settings from each application's default_settings.py file.
     """
+
+    def add_arguments(self, parser):
+        parser.add_argument('--reset',
+            action='store_true',
+            dest='reset',
+            default=False,
+            help='Reset all setting values to defaults')
+
     def handle(self, *args, **options):
+        reset = options.get('reset', False)
         if not args:
             for app in settings.INSTALLED_APPS:
                 mod = import_module(app)
                 if module_has_submodule(mod, "default_settings"):
                     try:
                         def_mod = import_module("%s.default_settings" % app)
-                        def_mod.load_defaults()
+                        def_mod.load_defaults(reset=reset, stdout=self.stdout)
                     except:
                         raise
         else:
@@ -41,6 +50,6 @@ class Command(BaseCommand):
                 if module_has_submodule(mod, "default_settings"):
                     try:
                         def_mod = import_module("%s.default_settings" % app)
-                        def_mod.load_defaults()
+                        def_mod.load_defaults(reset=reset, stdout=self.stdout)
                     except:
                         raise

--- a/evewspace/core/utils.py
+++ b/evewspace/core/utils.py
@@ -23,3 +23,13 @@ def get_config(name, user):
         return ConfigEntry.objects.get(name=name, user=user)
     except ConfigEntry.DoesNotExist:
         return ConfigEntry.objects.get(name=name, user=None)
+
+def load_defaults(defaults, reset=False, stdout=None):
+    if stdout is None:
+        from sys import stdout
+    for setting in defaults:
+        config = ConfigEntry.objects.get_or_create(name=setting[0], user=None)[0]
+        if config.pk is None or reset:
+            stdout.write("Setting %s=%s" % (setting[0], setting[1]))
+            config.value = setting[1]
+            config.save()


### PR DESCRIPTION
This changes a bit how `./manage.py defaultsettings` works. It adds extra option `--reset` that can be used to reset settings to defaults and without it it will only add missing settings.

IMHO this is better for upgrades than plain reset.
