### PR TITLE
Use template caching if debug mode is off

### DIFF
--- a/evewspace/evewspace/settings.py
+++ b/evewspace/evewspace/settings.py
@@ -245,3 +245,9 @@ except NameError:
     except ImportError:
         pass
 
+
+if not DEBUG:
+    # when not in debug mode, add cached loader on top of template loaders
+    TEMPLATE_LOADERS = (
+        ('django.template.loaders.cached.Loader', TEMPLATE_LOADERS),
+    )


### PR DESCRIPTION
This is a bit of a hack on top of a hack. Idea is that if local_settings has DEBUG=False, this will add caching to template loader chain.

I'm not totally sure if this actually works as expected as I don't know how to validate. It should though :)

So review / test from someone else is welcome.
