### PR TITLE
Add generic wsgi for gunicorn (and maybe apache)

### DIFF
--- a/evewspace/wsgi.py
+++ b/evewspace/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for mysite project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
+"""
+
+import os, sys
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "evewspace.settings")
+
+application = get_wsgi_application()


### PR DESCRIPTION
Apparently `gunicorn_django` has deprecated, so in the future we should use wsgi file. I added this django-admin generated file. It also could be in evewspace subfolder, but personally I like this better. Owner of the project, can change it to better place.

In addition to this I use systemd to manage the gunicorn and celery processes. I didn't know good places for them, so I add them in this comment for now.

``` sh
$ cat /etc/systemd/system/www-evewspace-gunicorn.service 
[Unit]
Description=EVE W-Space gunicorn
PartOf=nginx.service

[Service]
WorkingDirectory=/opt/evewspace/eve-wspace/evewspace/
User=evewspace
Group=nogroup
Environment="PATH=/opt/evewspace/eve-wspace/bin/"
ExecStart=/opt/evewspace/eve-wspace/bin/gunicorn --workers=2 -b 127.0.0.1:8000 wsgi:application
RestartSec=15
Restart=always

[Install]
WantedBy=multi-user.target
```

``` sh
$ cat /etc/systemd/system/www-evewspace-celeryd.service 
[Unit]
Description=EVE W-Space celeryd
PartOf=nginx.service
Pequires=www-evewpsace-gunicorn

[Service]
WorkingDirectory=/opt/evewspace/eve-wspace/evewspace/
User=evewspace
Group=nogroup
Environment="PATH=/opt/evewspace/eve-wspace/bin"
ExecStart=/opt/evewspace/eve-wspace/bin/python manage.py celery worker -B --loglevel=info
RestartSec=15
Restart=always

[Install]
WantedBy=multi-user.target
```

Remember to enable those servces `systemctl enable www-evewspace-*`
