### PR TITLE
Strip useless information from gas/relic/data sites

### DIFF
--- a/evewspace/Map/models.py
+++ b/evewspace/Map/models.py
@@ -803,7 +803,8 @@ class Signature(models.Model):
                             new_info += " Covert Research"
                         self.info = new_info
                         return
-                self.info = ' '.join(info.split(' ')[-2:])
+                if info.count(' ') >= 2:
+                    self.info = info.split(' ', 3)[2]
 
 
     def update_from_tsv(self, user, wascreated, row, map_system):

--- a/evewspace/Map/models.py
+++ b/evewspace/Map/models.py
@@ -803,7 +803,7 @@ class Signature(models.Model):
                             new_info += " Covert Research"
                         self.info = new_info
                         return
-                self.info = info.split(' ', 3)[2]
+                self.info = ' '.join(info.split(' ')[-2:])
 
 
     def update_from_tsv(self, user, wascreated, row, map_system):

--- a/evewspace/Map/models.py
+++ b/evewspace/Map/models.py
@@ -803,8 +803,7 @@ class Signature(models.Model):
                             new_info += " Covert Research"
                         self.info = new_info
                         return
-                if info.count(' ') > 2:
-                    self.info = info.split(' ', 3)[2]
+                self.info = ' '.join(info.split(' ')[-2:])
 
 
     def update_from_tsv(self, user, wascreated, row, map_system):

--- a/evewspace/Map/models.py
+++ b/evewspace/Map/models.py
@@ -803,7 +803,8 @@ class Signature(models.Model):
                             new_info += " Covert Research"
                         self.info = new_info
                         return
-                self.info = ' '.join(info.split(' ')[-2:])
+                if info.count(' ') > 2:
+                    self.info = info.split(' ', 3)[2]
 
 
     def update_from_tsv(self, user, wascreated, row, map_system):


### PR DESCRIPTION
Could probably do with improvements / tidying, but this should intercept signatures being bulk-imported and strip out the useless information in the title: 

Remove "Unsecured Frontier" from "Unsecured Frontier Database" etc from sleeper sites
Remove "Core Reservoir" from gas sites
Only leave "NULL" + race for hacking sites, with "Covert Research" for ghost sites.
