### PR TITLE
disable hole3, it's not used anyway and it broke my migration (no static 3 on wsystem in my db!)

### DIFF
--- a/evewspace/Map/migrations/0005_wsystem_statics.py
+++ b/evewspace/Map/migrations/0005_wsystem_statics.py
@@ -17,7 +17,7 @@ def combine_statics(apps, schema_editor):
         # Get all the static wormholes
         hole1 = wsystem.static1
         hole2 = wsystem.static2
-        hole3 = wsystem.static3
+        #hole3 = wsystem.static3
         # Add the wormholes to statics if the static exists
         try:
             static1 = WormholeType.objects.get(name=hole1)


### PR DESCRIPTION
Solves the most trivial part of issue #251 (MyISAM->InnoDB conversion/checks **not** included in this patch)
