### PR TITLE
Remove unrequired modal dialog redraw that was also broken

### DIFF
--- a/evewspace/core/static/js/base.js
+++ b/evewspace/core/static/js/base.js
@@ -17,7 +17,6 @@
 
 var draggable_x = 100
 var draggable_y = 100
-var dragged = 0
 
 $.ajaxSetup({
     beforeSend: function(xhr, settings) {
@@ -105,79 +104,18 @@ $(document).on("focus", ".towerAuto", function(){
        });
 });
 
-function makeModalHolderDraggable() {
+function recreateModalHolder() {
+	$("#response-container").css({top: draggable_y, left: draggable_x, width: '600px', position:'absolute'});
 	$("#response-container").draggable({
-        stop:function(event,ui) {
-	        var wrapper = $("#wrapper").offset();
-	        var borderLeft = parseInt($("#wrapper").css("border-left-width"),10);
-	        var borderTop = parseInt($("#wrapper").css("border-top-width"),10);
-	        var pos = ui.helper.offset();
-	        draggable_x = (pos.left - wrapper.left - borderLeft);
-	        draggable_y = (pos.top - wrapper.top - borderTop - 65);
-	        dragged = 1
-	        html = $( "#modalHolder" ).html();
-	        form_values = buildRequestStringData(" #response-container ");
-	        recreateModalHolder();
-	        $( "#modalHolder" ).append( html );
-	        $.each(form_values, function(key, value) {
-		        if($('[name="'+value["name"]+'"]').attr('type') !== 'checkbox' && $('[name="'+value["name"]+'"]').attr('type') !== 'radio'){
-					$('[name="'+value["name"]+'"]').val(value["val"]);
-				}
-				else if ($('[name="'+value["name"]+'"]').attr('type') == 'checkbox')
-				{
-					$('[name="'+value["name"]+'"]').prop('checked', true);
-				}
-				else {
-					$('[name="'+value["name"]+'"][value="'+value["val"]+'"').prop('checked', true);
-				}
-        	});
-    	}
+		stop:function(event,ui) {
+			var wrapper = $("#wrapper").offset();
+			var borderLeft = parseInt($("#wrapper").css("border-left-width"),10);
+			var borderTop = parseInt($("#wrapper").css("border-top-width"),10);
+			var pos = ui.helper.offset();
+			draggable_x = (pos.left - wrapper.left - borderLeft);
+			draggable_y = (pos.top - wrapper.top - borderTop - 65);
+			$("#response-container").css({height: '', right: '', bottom: ''});
+		}
 	});
-};
-
-function recreateModalHolder (){
-	if (dragged == 1){
-		$( "#response-container" ).remove();
-		div = "<div id='response-container' class='draggable-response-container'>"+
-					"<div id='cancelHolder'><i class='glyphicon glyphicon-remove' onclick='$("+'"#modalHolder"'+").parent().hide();\'></i></div>"+
-					"<div id='modalHolder' style='height: 100%; width: 100%;'></div>"+
-				"</div>";
-		$( ".container" ).append( div );
-		
-		$("#response-container").css({top: draggable_y, left: draggable_x, width: '600px', position:'absolute'});
-		$("#response-container").show();
-	}
-	makeModalHolderDraggable();
-}
-
-
-function buildRequestStringData(div_id) {
-    var requestString = "[";
-    selects = $(div_id).find('select');
-    inputs = $(div_id).find('input');
-    textareas = $(div_id).find('textarea');
-    for (var i = 0; i < selects.length; i++) {
-        requestString += ('{"name": "' + $(selects[i]).attr('name') +'", "val":"' +$(selects[i]).val() + '"},');
-    }
-    for (var i = 0; i < inputs.length; i++) {
-        if ($(inputs[i]).attr('type') !== 'checkbox' && $(inputs[i]).attr('type') !== 'radio') {
-            requestString += ('{"name": "' + $(inputs[i]).attr('name') +'", "val":"' + $(inputs[i]).val() +'"},');
-        } else {
-            if ($(inputs[i]).is(':checked')) {
-                requestString += ('{"name": "' + $(inputs[i]).attr('name') +'", "val":"' + $(inputs[i]).val() +'"},');
-            }
-        }
-    }
-    for (var i = 0; i < textareas.length; i++) {
-	    text_val = $(textareas[i]).val();
-	    text_val = text_val.replace(/\n/g, "\\n")
-					        .replace(/\r/g, "\\r")
-					        .replace(/\t/g, "\\t")
-					        .replace(/\f/g, "\\f")
-					        .replace(/"/g, '\\"');
-        requestString += ('{"name": "' + $(textareas[i]).attr('name') +'", "val":"' + text_val +'"},');
-    }
-    requestString = requestString.substring(0, requestString.length - 1);
-    requestString += "]";
-    return $.parseJSON(requestString);
+	$("#response-container").show();
 }


### PR DESCRIPTION
i expect that this huge code to support recreating modal dialog after drag even was there to handle height resize. It turns out that is not required. We just need to remove height value from the element and draggable will readd it on next drag (and then it's removed again afterwards).

This also means there shouldn't be any need to call `recreateModalHolder` all the time.

Also we could make better framwork so first tab in modal dielogs would be select automatically.
